### PR TITLE
Allow for request headers that are not dictionaries.

### DIFF
--- a/requests_opentracing/tracing.py
+++ b/requests_opentracing/tracing.py
@@ -31,6 +31,8 @@ class SessionTracing(requests.sessions.Session):
 
             if self._propagate:
                 headers = kwargs.setdefault('headers', {})
+                if type(headers) == requests.structures.CaseInsensitiveDict:
+                    headers = dict(headers)
                 try:
                     self._get_tracer().inject(span.context, Format.HTTP_HEADERS, headers)
                 except opentracing.UnsupportedFormatException:


### PR DESCRIPTION
The requests library implements a `CaseInsensitiveDict` structure that is
used for headers instead of a dictionary in some request models. This
causes problems in `jaeger-client-python` codecs which test if the
carrier param is an instance of `dict`.

This change checks for headers of this type and converts them to `type
dict`.